### PR TITLE
Add Docs and Install Instructions for More OSes

### DIFF
--- a/docs/install/MacOSX.md
+++ b/docs/install/MacOSX.md
@@ -1,0 +1,1 @@
+Link To Tutorial: https://youtu.be/ngSSNyX7pog

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -1,0 +1,41 @@
+Ubuntu Install.md
+----------------------
+
+1. Install gdebi app:
+
+sudo apt install gdebi
+2. Download Substratum Node 0.4.0 GUI version for Ubuntu
+
+Go to the official page https://substratum.net/open-beta
+
+Locate and download SubstratumNode-v0.4.0-Linux64-deb.zip, which is around 40 MB. Note that the small link to binaries is probably not for you since it doesn't contain graphic user interface.
+3. Unpack zip file
+
+You get a deb file of the Node. Put in in your home folder, or any where you can find.
+4. Install Substratum Node via gdebi
+
+Open the GDebi Package Installer from app laucher. Click File -> Open, locate your .deb file, click Install Package, and wait until the installation is complete.
+
+Now Substratum Node is installed to your system.
+Second,
+
+to make sure the Node runs properly, you may have to manually disable the service occupying port 53.
+
+You can check if port 53 is occupied by running command ss -lntup
+
+To disable the service occupying port 53 on thr latest Ubuntu 18.04, do the following:
+1. Run command
+
+sudo nano /etc/systemd/resolved.conf
+
+Append a new line in the text file - DNSStubListener=no
+
+Press key Ctrl-O, and then key ENTER to save the file, and then key Ctrl-X to exit.
+2. Run commands
+
+sudo systemctl daemon-reload
+
+sudo systemctl restart systemd-resolved.service
+Finally,
+
+run Substratum Node from app launcher

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -4,6 +4,7 @@ Ubuntu Install.md
 1. Install gdebi app:
 
 ```sudo apt install gdebi```
+
 2. Download Substratum Node 0.4.0 GUI version for Ubuntu
 
 Go to the official page https://substratum.net/open-beta

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -21,21 +21,22 @@ Second,
 
 to make sure the Node runs properly, you may have to manually disable the service occupying port 53.
 
-You can check if port 53 is occupied by running command ss -lntup
+You can check if port 53 is occupied by running command ```ss -lntup```
 
 To disable the service occupying port 53 on thr latest Ubuntu 18.04, do the following:
 1. Run command
 
-'sudo nano /etc/systemd/resolved.conf'
+```sudo nano /etc/systemd/resolved.conf```
 
-Append a new line in the text file '- DNSStubListener=no'
+Append a new line in the text file ```- DNSStubListener=no```
 
 Press key Ctrl-O, and then key ENTER to save the file, and then key Ctrl-X to exit.
 2. Run commands
 
-'sudo systemctl daemon-reload
+```sudo systemctl daemon-reload
 
-sudo systemctl restart systemd-resolved.service'
+sudo systemctl restart systemd-resolved.service
+```
 Finally,
 
 run Substratum Node from app launcher

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -3,7 +3,7 @@ Ubuntu Install.md
 
 1. Install gdebi app:
 
-sudo apt install gdebi
+'sudo apt install gdebi'
 2. Download Substratum Node 0.4.0 GUI version for Ubuntu
 
 Go to the official page https://substratum.net/open-beta
@@ -26,16 +26,16 @@ You can check if port 53 is occupied by running command ss -lntup
 To disable the service occupying port 53 on thr latest Ubuntu 18.04, do the following:
 1. Run command
 
-sudo nano /etc/systemd/resolved.conf
+'sudo nano /etc/systemd/resolved.conf'
 
-Append a new line in the text file - DNSStubListener=no
+Append a new line in the text file '- DNSStubListener=no'
 
 Press key Ctrl-O, and then key ENTER to save the file, and then key Ctrl-X to exit.
 2. Run commands
 
-sudo systemctl daemon-reload
+'sudo systemctl daemon-reload
 
-sudo systemctl restart systemd-resolved.service
+sudo systemctl restart systemd-resolved.service'
 Finally,
 
 run Substratum Node from app launcher

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -41,3 +41,5 @@ sudo systemctl restart systemd-resolved.service
 Finally,
 
 run Substratum Node from app launcher
+
+Source: https://www.reddit.com/r/SubstratumNetwork/comments/9d8etd/why_doesnt_substratumnet_work_with_my_os/e5i2az6

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -43,3 +43,5 @@ Finally,
 run Substratum Node from app launcher
 
 Source: https://www.reddit.com/r/SubstratumNetwork/comments/9d8etd/why_doesnt_substratumnet_work_with_my_os/e5i2az6
+
+Tutorial URL: https://youtu.be/T0GHcAS-pYM

--- a/docs/install/Ubuntu.md
+++ b/docs/install/Ubuntu.md
@@ -3,7 +3,7 @@ Ubuntu Install.md
 
 1. Install gdebi app:
 
-'sudo apt install gdebi'
+```sudo apt install gdebi```
 2. Download Substratum Node 0.4.0 GUI version for Ubuntu
 
 Go to the official page https://substratum.net/open-beta


### PR DESCRIPTION
Most of these tutorials have been just copied from the internet so, proceed with caution.
Most OSes didn't have any install instructions. I think this could help with adoption. :)

Edit: Maintainers, feel free to edit or reject this. If you want to minimize file creation I would recommend adding it to the README.md file.